### PR TITLE
Add PHREAK v5 control tower scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,17 @@ PHREAK v4 is a comprehensive Android operator console that provides a unified in
 
 > **Looking toward PHREAK v5?** A full control-tower blueprint that extends the red/green/blue layering into multi-device orchestration, forensic safety rails, cloud control planes, and plugin-driven extensibility now lives in [`docs/PHREAK_v5_architecture.md`](docs/PHREAK_v5_architecture.md).
 
+### PHREAK v5 Control Tower Package
+
+The repository now includes a `phreak_v5` Python package that converts the v5 architecture blueprint into code. The package wires together red/green/blue layers with telemetry and auditing so downstream interfaces can share a common control plane.
+
+* **Core layer (`phreak_v5.core`)** &mdash; connection matrix, policy engine, command router, audit logging, and a pluggable secret vault.
+* **Operator services (`phreak_v5.services`)** &mdash; device graph orchestrator, forensics hub, firmware store, backup scheduler, heuristic ML diagnostics, and a JSON-manifest plugin runtime.
+* **Presentation surfaces (`phreak_v5.presentation`)** &mdash; stubs for a curses control room, web cockpit state exporter, automation API facade, and observability metrics collector.
+* **Orchestrator (`phreak_v5.PhreakControlTower`)** &mdash; high-level façade that instantiates all subsystems, exposes helper methods for device registration, job dispatch, secrets, firmware ingestion, backups, and forensics collection.
+
+This scaffolding is intentionally light on platform-specific logic so it can evolve alongside the blueprint while still providing working telemetry, logging, and storage primitives for experimentation.
+
 ### Core Architecture
 
 The tool operates through several interconnected layers:

--- a/phreak_v5/__init__.py
+++ b/phreak_v5/__init__.py
@@ -1,0 +1,181 @@
+"""High-level orchestration for the PHREAK v5 control tower."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional, Sequence
+
+from .config import ControlTowerConfig
+from .core.connection import ConnectionMatrix
+from .core.logging import AuditLoggingKernel
+from .core.policy import PolicyEngine, PolicyRule
+from .core.router import CommandRouter
+from .core.vault import SecurityVault
+from .models import CommandRequest, Device, DeviceBatch, PolicyContext
+from .services.backup import BackupSyncEngine
+from .services.device_graph import DeviceGraphOrchestrator
+from .services.firmware import FirmwareSuite
+from .services.forensics import ForensicsHub
+from .services.ml import MLDiagnostics
+from .services.plugins import PluginRuntime
+from .telemetry import TelemetryBus
+
+
+@dataclass(slots=True)
+class ControlTowerComponents:
+    """Aggregated component references used by the orchestrator."""
+
+    connection_matrix: ConnectionMatrix
+    policy_engine: PolicyEngine
+    command_router: CommandRouter
+    audit_log: AuditLoggingKernel
+    vault: SecurityVault
+    device_graph: DeviceGraphOrchestrator
+    forensics_hub: ForensicsHub
+    firmware_suite: FirmwareSuite
+    backup_engine: BackupSyncEngine
+    ml_diagnostics: MLDiagnostics
+    plugin_runtime: PluginRuntime
+    telemetry: TelemetryBus
+
+
+class PhreakControlTower:
+    """Top-level facade wiring together the PHREAK v5 subsystems."""
+
+    def __init__(
+        self,
+        config: Optional[ControlTowerConfig] = None,
+        *,
+        policy_rules: Optional[Sequence[PolicyRule]] = None,
+    ) -> None:
+        self.config = config or ControlTowerConfig.default()
+        self.telemetry = TelemetryBus()
+
+        self.audit_log = AuditLoggingKernel(
+            storage_path=self.config.paths.audit_log,
+            telemetry=self.telemetry,
+        )
+        self.vault = SecurityVault(
+            storage_path=self.config.paths.vault,
+            master_key=self.config.security.master_key,
+            telemetry=self.telemetry,
+        )
+
+        self.connection_matrix = ConnectionMatrix(
+            telemetry=self.telemetry, audit_log=self.audit_log
+        )
+        self.policy_engine = PolicyEngine(
+            policy_rules=policy_rules or [],
+            telemetry=self.telemetry,
+        )
+        self.command_router = CommandRouter(
+            connection_matrix=self.connection_matrix,
+            policy_engine=self.policy_engine,
+            audit_log=self.audit_log,
+            telemetry=self.telemetry,
+        )
+
+        self.device_graph = DeviceGraphOrchestrator(
+            telemetry=self.telemetry, audit_log=self.audit_log
+        )
+        self.forensics_hub = ForensicsHub(
+            audit_log=self.audit_log,
+            telemetry=self.telemetry,
+        )
+        self.firmware_suite = FirmwareSuite(
+            telemetry=self.telemetry,
+            audit_log=self.audit_log,
+            storage_path=self.config.paths.firmware_store,
+        )
+        self.backup_engine = BackupSyncEngine(
+            telemetry=self.telemetry,
+            storage_path=self.config.paths.backup_store,
+        )
+        self.ml_diagnostics = MLDiagnostics(telemetry=self.telemetry)
+        self.plugin_runtime = PluginRuntime(
+            search_paths=list(self.config.paths.plugin_roots),
+            telemetry=self.telemetry,
+            audit_log=self.audit_log,
+        )
+
+    @property
+    def components(self) -> ControlTowerComponents:
+        return ControlTowerComponents(
+            connection_matrix=self.connection_matrix,
+            policy_engine=self.policy_engine,
+            command_router=self.command_router,
+            audit_log=self.audit_log,
+            vault=self.vault,
+            device_graph=self.device_graph,
+            forensics_hub=self.forensics_hub,
+            firmware_suite=self.firmware_suite,
+            backup_engine=self.backup_engine,
+            ml_diagnostics=self.ml_diagnostics,
+            plugin_runtime=self.plugin_runtime,
+            telemetry=self.telemetry,
+        )
+
+    # -- Device lifecycle -------------------------------------------------
+    def register_devices(self, devices: Iterable[Device]) -> None:
+        """Register devices in the graph and connection matrix."""
+        for device in devices:
+            self.connection_matrix.register_device(device)
+            self.device_graph.register_device(device)
+
+    def remove_device(self, device_id: str) -> None:
+        self.connection_matrix.unregister_device(device_id)
+        self.device_graph.remove_device(device_id)
+
+    # -- Command dispatch -------------------------------------------------
+    async def dispatch(self, request: CommandRequest) -> None:
+        """Submit a command request and record results in services."""
+        context = PolicyContext.from_request(request)
+        self.audit_log.record_command_request(request)
+        await self.command_router.dispatch(request, context)
+
+    async def dispatch_batch(self, batch: DeviceBatch, request: CommandRequest) -> None:
+        resolved = self.device_graph.resolve_batch(batch)
+        request = request.with_devices(resolved.device_ids)
+        await self.dispatch(request)
+
+    # -- Maintenance ------------------------------------------------------
+    def bootstrap(self) -> None:
+        """Ensure storage paths exist and perform first-run setup."""
+        for path in self.config.paths.all_paths():
+            if path.suffix:
+                path.parent.mkdir(parents=True, exist_ok=True)
+            else:
+                path.mkdir(parents=True, exist_ok=True)
+        self.audit_log.bootstrap()
+        self.vault.bootstrap()
+        self.telemetry.emit("control_tower.bootstrap", {})
+
+    # -- Secrets ----------------------------------------------------------
+    def store_secret(self, name: str, value: str, *, tags: Optional[Sequence[str]] = None) -> None:
+        self.vault.store_secret(name, value, tags=tags)
+
+    def load_secret(self, name: str) -> Optional[str]:
+        return self.vault.retrieve_secret(name)
+
+    # -- Firmware/Backups -------------------------------------------------
+    def ingest_firmware(self, path: Path, *, metadata: Optional[dict] = None) -> str:
+        return self.firmware_suite.ingest_firmware(path, metadata=metadata)
+
+    def schedule_backup(self, device_id: str) -> Path:
+        return self.backup_engine.schedule_backup(device_id)
+
+    # -- Forensics --------------------------------------------------------
+    async def collect_forensics(self, device_id: str) -> Path:
+        return await self.forensics_hub.collect_snapshot(device_id, self.command_router)
+
+    # -- Plugins ----------------------------------------------------------
+    def load_plugins(self) -> None:
+        self.plugin_runtime.scan()
+        for plugin in self.plugin_runtime.plugins:
+            self.telemetry.emit(
+                "plugin.loaded",
+                {"name": plugin.metadata.name, "version": plugin.metadata.version},
+            )
+
+
+__all__ = ["PhreakControlTower", "ControlTowerComponents"]

--- a/phreak_v5/config.py
+++ b/phreak_v5/config.py
@@ -1,0 +1,59 @@
+"""Configuration helpers for the PHREAK v5 control tower."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Tuple
+
+
+@dataclass(slots=True)
+class PathConfig:
+    root: Path = Path("~/.phreak").expanduser()
+    audit_log_name: str = "audit.log.jsonl"
+    vault_name: str = "vault.json"
+    firmware_store_name: str = "firmware"
+    backup_store_name: str = "backups"
+    plugin_dirs: Tuple[str, ...] = ("plugins",)
+
+    @property
+    def audit_log(self) -> Path:
+        return self.root / self.audit_log_name
+
+    @property
+    def vault(self) -> Path:
+        return self.root / self.vault_name
+
+    @property
+    def firmware_store(self) -> Path:
+        return self.root / self.firmware_store_name
+
+    @property
+    def backup_store(self) -> Path:
+        return self.root / self.backup_store_name
+
+    @property
+    def plugin_roots(self) -> Tuple[Path, ...]:
+        return tuple(self.root / name for name in self.plugin_dirs)
+
+    def all_paths(self) -> Iterable[Path]:
+        yield self.audit_log
+        yield self.vault
+        yield self.firmware_store
+        yield self.backup_store
+        for plugin_root in self.plugin_roots:
+            yield plugin_root
+
+
+@dataclass(slots=True)
+class SecurityConfig:
+    master_key: str = "phreak-default-master-key"
+
+
+@dataclass(slots=True)
+class ControlTowerConfig:
+    paths: PathConfig = field(default_factory=PathConfig)
+    security: SecurityConfig = field(default_factory=SecurityConfig)
+
+    @classmethod
+    def default(cls) -> "ControlTowerConfig":
+        return cls()

--- a/phreak_v5/core/__init__.py
+++ b/phreak_v5/core/__init__.py
@@ -1,0 +1,15 @@
+"""Core layer of the PHREAK v5 architecture."""
+from .connection import ConnectionMatrix, LoopbackConnector
+from .logging import AuditLoggingKernel
+from .policy import PolicyEngine
+from .router import CommandRouter
+from .vault import SecurityVault
+
+__all__ = [
+    "ConnectionMatrix",
+    "LoopbackConnector",
+    "AuditLoggingKernel",
+    "PolicyEngine",
+    "CommandRouter",
+    "SecurityVault",
+]

--- a/phreak_v5/core/connection.py
+++ b/phreak_v5/core/connection.py
@@ -1,0 +1,157 @@
+"""Connection management for PHREAK v5."""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, Optional, Protocol
+
+from ..models import CommandRequest, CommandResult, CommandStatus, Device
+from ..telemetry import TelemetryBus
+
+if True:  # typing imports
+    from .logging import AuditLoggingKernel
+
+
+class DeviceConnector(Protocol):
+    """Protocol implemented by device transport adapters."""
+
+    async def execute(self, request: CommandRequest) -> CommandResult:
+        ...
+
+
+@dataclass(slots=True)
+class ConnectionState:
+    device: Device
+    connector: Optional[DeviceConnector] = None
+    last_seen: datetime = field(default_factory=datetime.utcnow)
+    healthy: bool = True
+    transport: str = "unknown"
+
+
+class NullConnector:
+    """Fallback connector used when no transport is registered."""
+
+    async def execute(self, request: CommandRequest) -> CommandResult:
+        result = CommandResult(
+            request_id=request.request_id,
+            device_id=request.device_ids[0] if request.device_ids else "unknown",
+            status=CommandStatus.REJECTED,
+        )
+        result.mark_complete(
+            CommandStatus.REJECTED,
+            stderr="No connector registered for device",
+            exit_code=1,
+        )
+        return result
+
+
+class LoopbackConnector:
+    """Connector that echoes commands for testing purposes."""
+
+    async def execute(self, request: CommandRequest) -> CommandResult:
+        device_id = request.device_ids[0] if request.device_ids else "unknown"
+        result = CommandResult(
+            request_id=request.request_id,
+            device_id=device_id,
+            status=CommandStatus.SUCCESS,
+        )
+        result.mark_running()
+        result.mark_complete(
+            CommandStatus.SUCCESS,
+            stdout=f"loopback:{device_id}:{request.action}",
+            exit_code=0,
+        )
+        return result
+
+
+class ConnectionMatrix:
+    """Maintains registered devices and their transport connectors."""
+
+    def __init__(self, *, telemetry: TelemetryBus, audit_log: "AuditLoggingKernel") -> None:
+        self.telemetry = telemetry
+        self.audit_log = audit_log
+        self._states: Dict[str, ConnectionState] = {}
+        self._default_connector = NullConnector()
+        self._lock = asyncio.Lock()
+
+    def register_device(self, device: Device, *, connector: Optional[DeviceConnector] = None) -> None:
+        self._states[device.device_id] = ConnectionState(
+            device=device,
+            connector=connector,
+            transport=device.connection_uri.split(":", 1)[0],
+        )
+        self.audit_log.append_custom(
+            "connection.register", {"device_id": device.device_id, "transport": device.connection_uri}
+        )
+        self.telemetry.emit(
+            "connection.device_registered",
+            {"device_id": device.device_id, "transport": device.connection_uri},
+        )
+
+    def unregister_device(self, device_id: str) -> None:
+        if device_id in self._states:
+            del self._states[device_id]
+            self.audit_log.append_custom(
+                "connection.unregister", {"device_id": device_id}
+            )
+            self.telemetry.emit(
+                "connection.device_unregistered", {"device_id": device_id}
+            )
+
+    def bind_connector(self, device_id: str, connector: DeviceConnector) -> None:
+        state = self._states.get(device_id)
+        if not state:
+            raise KeyError(f"Unknown device: {device_id}")
+        state.connector = connector
+        state.last_seen = datetime.utcnow()
+        self.telemetry.emit(
+            "connection.connector_bound",
+            {"device_id": device_id, "transport": state.transport},
+        )
+
+    def get_state(self, device_id: str) -> Optional[ConnectionState]:
+        return self._states.get(device_id)
+
+    async def execute(self, device_id: str, request: CommandRequest) -> CommandResult:
+        async with self._lock:
+            state = self._states.get(device_id)
+            if not state:
+                result = CommandResult(
+                    request_id=request.request_id,
+                    device_id=device_id,
+                    status=CommandStatus.REJECTED,
+                )
+                result.mark_complete(
+                    CommandStatus.REJECTED,
+                    stderr="Device not registered",
+                    exit_code=1,
+                )
+                return result
+
+            connector = state.connector or self._default_connector
+            state.last_seen = datetime.utcnow()
+
+        result = await connector.execute(request)
+        state.healthy = result.status not in {CommandStatus.FAILED, CommandStatus.REJECTED}
+        self.telemetry.emit(
+            "connection.command_completed",
+            {
+                "device_id": device_id,
+                "request_id": request.request_id,
+                "status": result.status.value,
+                "exit_code": result.exit_code,
+            },
+        )
+        return result
+
+    def list_devices(self) -> Dict[str, ConnectionState]:
+        return dict(self._states)
+
+
+__all__ = [
+    "ConnectionMatrix",
+    "DeviceConnector",
+    "ConnectionState",
+    "LoopbackConnector",
+]

--- a/phreak_v5/core/logging.py
+++ b/phreak_v5/core/logging.py
@@ -1,0 +1,132 @@
+"""Tamper-evident audit logging for PHREAK v5."""
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import List
+
+from ..models import CommandRequest, CommandResult
+from ..telemetry import TelemetryBus
+
+
+@dataclass(slots=True)
+class AuditRecord:
+    timestamp: str
+    kind: str
+    payload: dict
+    hash: str
+    prev_hash: str
+
+
+class AuditLoggingKernel:
+    """Append-only audit log with SHA-256 hash chaining."""
+
+    def __init__(self, *, storage_path: Path, telemetry: TelemetryBus) -> None:
+        self.storage_path = storage_path
+        self.telemetry = telemetry
+        self._last_hash = "0" * 64
+        if self.storage_path.exists():
+            self._last_hash = self._read_last_hash()
+
+    def bootstrap(self) -> None:
+        self.storage_path.parent.mkdir(parents=True, exist_ok=True)
+        if not self.storage_path.exists():
+            self.storage_path.write_text("")
+            self._last_hash = "0" * 64
+
+    def record_command_request(self, request: CommandRequest) -> None:
+        payload = {
+            "request_id": request.request_id,
+            "action": request.action,
+            "device_ids": list(request.device_ids),
+            "arguments": dict(request.arguments),
+            "requested_by": request.requested_by,
+            "priority": request.priority.name,
+            "created_at": request.created_at.isoformat(),
+        }
+        self._append("command_request", payload)
+
+    def record_command_result(self, result: CommandResult) -> None:
+        payload = {
+            "request_id": result.request_id,
+            "device_id": result.device_id,
+            "status": result.status.value,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+            "exit_code": result.exit_code,
+            "started_at": result.started_at.isoformat() if result.started_at else None,
+            "completed_at": result.completed_at.isoformat() if result.completed_at else None,
+        }
+        self._append("command_result", payload)
+
+    def append_custom(self, kind: str, payload: dict) -> None:
+        self._append(kind, payload)
+
+    def tail(self, limit: int = 20) -> List[AuditRecord]:
+        if not self.storage_path.exists():
+            return []
+        lines = self.storage_path.read_text().strip().splitlines()
+        records: List[AuditRecord] = []
+        for line in lines[-limit:]:
+            if not line:
+                continue
+            data = json.loads(line)
+            records.append(AuditRecord(**data))
+        return records
+
+    def verify(self) -> bool:
+        prev_hash = "0" * 64
+        for record in self.tail(limit=10_000):
+            payload = {
+                "timestamp": record.timestamp,
+                "kind": record.kind,
+                "payload": record.payload,
+            }
+            expected = hashlib.sha256((prev_hash + json.dumps(payload, sort_keys=True)).encode()).hexdigest()
+            if expected != record.hash or record.prev_hash != prev_hash:
+                return False
+            prev_hash = record.hash
+        return True
+
+    def _append(self, kind: str, payload: dict) -> None:
+        self.storage_path.parent.mkdir(parents=True, exist_ok=True)
+        record_payload = {
+            "timestamp": datetime.utcnow().isoformat(),
+            "kind": kind,
+            "payload": payload,
+        }
+        digest = hashlib.sha256(
+            (self._last_hash + json.dumps(record_payload, sort_keys=True)).encode()
+        ).hexdigest()
+        record = AuditRecord(
+            timestamp=record_payload["timestamp"],
+            kind=kind,
+            payload=payload,
+            hash=digest,
+            prev_hash=self._last_hash,
+        )
+        with self.storage_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(asdict(record)) + "\n")
+        self._last_hash = digest
+        self.telemetry.emit(
+            "audit.record_appended",
+            {"kind": kind, "hash": digest, "prev_hash": record.prev_hash},
+        )
+
+    def _read_last_hash(self) -> str:
+        try:
+            with self.storage_path.open("r", encoding="utf-8") as handle:
+                for line in reversed(handle.readlines()):
+                    if not line.strip():
+                        continue
+                    data = json.loads(line)
+                    return data.get("hash", "0" * 64)
+        except FileNotFoundError:
+            return "0" * 64
+        return "0" * 64
+
+
+__all__ = ["AuditLoggingKernel", "AuditRecord"]

--- a/phreak_v5/core/policy.py
+++ b/phreak_v5/core/policy.py
@@ -1,0 +1,142 @@
+"""Policy evaluation for PHREAK v5."""
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence
+
+from ..models import PolicyContext, PolicyDecision, PolicyRule
+from ..telemetry import TelemetryBus
+
+SAFE_GLOBALS = {"len": len, "any": any, "all": all, "set": set}
+
+
+class UnsafeExpressionError(ValueError):
+    """Raised when a policy expression contains unsupported constructs."""
+
+
+class _PolicyExpressionValidator(ast.NodeVisitor):
+    allowed_nodes = {
+        ast.Expression,
+        ast.BoolOp,
+        ast.BinOp,
+        ast.UnaryOp,
+        ast.IfExp,
+        ast.Compare,
+        ast.Call,
+        ast.Name,
+        ast.Load,
+        ast.Constant,
+        ast.List,
+        ast.Tuple,
+        ast.Dict,
+        ast.Subscript,
+        ast.Slice,
+        ast.Index,
+        ast.Attribute,
+        ast.And,
+        ast.Or,
+        ast.Not,
+        ast.Eq,
+        ast.NotEq,
+        ast.Lt,
+        ast.LtE,
+        ast.Gt,
+        ast.GtE,
+        ast.In,
+        ast.NotIn,
+        ast.Is,
+        ast.IsNot,
+    }
+
+    allowed_calls = {"len", "any", "all", "set"}
+
+    def visit(self, node: ast.AST) -> None:  # type: ignore[override]
+        if type(node) not in self.allowed_nodes:
+            raise UnsafeExpressionError(f"Unsupported expression: {ast.dump(node)}")
+        return super().visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
+        if not isinstance(node.func, ast.Name) or node.func.id not in self.allowed_calls:
+            raise UnsafeExpressionError(f"Function {ast.dump(node.func)} not permitted")
+        self.generic_visit(node)
+
+
+@dataclass(slots=True)
+class PolicyEvaluation:
+    rule: PolicyRule
+    matched: bool
+
+
+class PolicyEngine:
+    """Evaluates policy rules before command execution."""
+
+    def __init__(
+        self,
+        *,
+        policy_rules: Sequence[PolicyRule],
+        telemetry: TelemetryBus,
+    ) -> None:
+        self.telemetry = telemetry
+        self.rules: List[PolicyRule] = list(policy_rules)
+
+    def add_rule(self, rule: PolicyRule) -> None:
+        self.rules.append(rule)
+
+    def evaluate(self, context: PolicyContext, *, extra: Optional[Dict[str, object]] = None) -> PolicyDecision:
+        env: Dict[str, object] = {
+            "device_ids": tuple(context.device_ids),
+            "action": context.action,
+            "requested_by": context.requested_by,
+            "arguments": dict(context.arguments),
+        }
+        if extra:
+            env.update(extra)
+
+        denies: List[str] = []
+        matched_rules: List[PolicyEvaluation] = []
+
+        for rule in self.rules:
+            if not rule.condition:
+                continue
+            try:
+                matched = self._evaluate_condition(rule.condition, env)
+            except UnsafeExpressionError as exc:
+                denies.append(f"Rule {rule.name} invalid: {exc}")
+                matched = False
+            matched_rules.append(PolicyEvaluation(rule, matched))
+            if matched and rule.effect.lower() == "deny":
+                denies.append(rule.description or rule.name)
+
+        if denies:
+            decision = PolicyDecision.deny(denies)
+        else:
+            decision = PolicyDecision.allow()
+
+        self.telemetry.emit(
+            "policy.evaluated",
+            {
+                "action": context.action,
+                "requested_by": context.requested_by,
+                "allowed": decision.allowed,
+                "denies": list(decision.reasons),
+                "matched_rules": [
+                    {
+                        "name": eval_result.rule.name,
+                        "matched": eval_result.matched,
+                        "effect": eval_result.rule.effect,
+                    }
+                    for eval_result in matched_rules
+                ],
+            },
+        )
+        return decision
+
+    def _evaluate_condition(self, condition: str, env: Dict[str, object]) -> bool:
+        tree = ast.parse(condition, mode="eval")
+        _PolicyExpressionValidator().visit(tree)
+        compiled = compile(tree, "<policy>", "eval")
+        return bool(eval(compiled, {"__builtins__": SAFE_GLOBALS}, env))
+
+
+__all__ = ["PolicyEngine", "PolicyRule", "PolicyDecision"]

--- a/phreak_v5/core/router.py
+++ b/phreak_v5/core/router.py
@@ -1,0 +1,99 @@
+"""Command routing for PHREAK v5."""
+from __future__ import annotations
+
+import asyncio
+from typing import Dict, Optional, Sequence
+
+from ..models import CommandRequest, CommandResult, CommandStatus, PolicyContext
+from ..telemetry import TelemetryBus
+
+if True:  # typing imports
+    from .connection import ConnectionMatrix
+    from .logging import AuditLoggingKernel
+    from .policy import PolicyEngine
+
+
+class CommandRouter:
+    """Routes normalized command requests to the correct connector."""
+
+    def __init__(
+        self,
+        *,
+        connection_matrix: "ConnectionMatrix",
+        policy_engine: "PolicyEngine",
+        audit_log: "AuditLoggingKernel",
+        telemetry: TelemetryBus,
+        concurrency: int = 8,
+    ) -> None:
+        self.connection_matrix = connection_matrix
+        self.policy_engine = policy_engine
+        self.audit_log = audit_log
+        self.telemetry = telemetry
+        self._semaphore = asyncio.Semaphore(concurrency)
+
+    async def dispatch(
+        self,
+        request: CommandRequest,
+        context: PolicyContext,
+        *,
+        extra: Optional[Dict[str, object]] = None,
+    ) -> None:
+        if not request.device_ids:
+            raise ValueError("Command request must target at least one device")
+
+        decision = self.policy_engine.evaluate(context, extra=extra)
+        if not decision.allowed:
+            await self._handle_denied(request, decision.reasons)
+            return
+
+        await asyncio.gather(
+            *(
+                self._dispatch_to_device(request, device_id)
+                for device_id in request.device_ids
+            )
+        )
+
+    async def _dispatch_to_device(self, request: CommandRequest, device_id: str) -> CommandResult:
+        async with self._semaphore:
+            single_request = request.with_devices([device_id])
+            self.telemetry.emit(
+                "command.dispatched",
+                {"request_id": request.request_id, "device_id": device_id},
+            )
+            result = await self.connection_matrix.execute(device_id, single_request)
+            self.audit_log.record_command_result(result)
+            self.telemetry.emit(
+                "command.completed",
+                {
+                    "request_id": request.request_id,
+                    "device_id": device_id,
+                    "status": result.status.value,
+                    "exit_code": result.exit_code,
+                },
+            )
+            return result
+
+    async def _handle_denied(self, request: CommandRequest, reasons: Sequence[str]) -> None:
+        for device_id in request.device_ids:
+            result = CommandResult(
+                request_id=request.request_id,
+                device_id=device_id,
+                status=CommandStatus.REJECTED,
+            )
+            result.mark_complete(
+                CommandStatus.REJECTED,
+                stderr="; ".join(reasons) if reasons else "Policy denied",
+                exit_code=1,
+            )
+            self.audit_log.record_command_result(result)
+            self.telemetry.emit(
+                "command.rejected",
+                {
+                    "request_id": request.request_id,
+                    "device_id": device_id,
+                    "reasons": list(reasons),
+                },
+            )
+
+
+__all__ = ["CommandRouter"]

--- a/phreak_v5/core/vault.py
+++ b/phreak_v5/core/vault.py
@@ -1,0 +1,149 @@
+"""Minimal secret storage for PHREAK v5."""
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Optional, Sequence
+
+from ..telemetry import TelemetryBus
+
+try:
+    from cryptography.fernet import Fernet  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    Fernet = None
+
+
+@dataclass(slots=True)
+class VaultEntry:
+    value: str
+    tags: Sequence[str]
+    created_at: str
+    updated_at: str
+
+
+class _SimpleCipher:
+    """Fallback XOR-based cipher (not for production use)."""
+
+    def __init__(self, key: bytes) -> None:
+        self._key = key
+
+    def encrypt(self, plaintext: str) -> str:
+        data = plaintext.encode("utf-8")
+        cipher = bytes(b ^ self._key[i % len(self._key)] for i, b in enumerate(data))
+        return base64.urlsafe_b64encode(cipher).decode("ascii")
+
+    def decrypt(self, token: str) -> str:
+        data = base64.urlsafe_b64decode(token.encode("ascii"))
+        plain = bytes(b ^ self._key[i % len(self._key)] for i, b in enumerate(data))
+        return plain.decode("utf-8")
+
+
+class SecurityVault:
+    """Stores secrets with optional encryption and tagging."""
+
+    def __init__(
+        self,
+        *,
+        storage_path: Path,
+        master_key: str,
+        telemetry: Optional[TelemetryBus] = None,
+    ) -> None:
+        self.storage_path = storage_path
+        self.telemetry = telemetry
+        key_bytes = master_key.encode("utf-8")
+        if Fernet:
+            self._cipher = Fernet(base64.urlsafe_b64encode(key_bytes.ljust(32, b"0")[:32]))
+            self._mode = "fernet"
+        else:
+            self._cipher = _SimpleCipher(key_bytes)
+            self._mode = "xor"
+        self._entries: Dict[str, VaultEntry] = {}
+        self._load()
+
+    def bootstrap(self) -> None:
+        self.storage_path.parent.mkdir(parents=True, exist_ok=True)
+        if not self.storage_path.exists():
+            self._write()
+
+    def store_secret(self, name: str, value: str, *, tags: Optional[Sequence[str]] = None) -> None:
+        now = datetime.utcnow().isoformat()
+        encrypted = self._encrypt(value)
+        entry = VaultEntry(
+            value=encrypted,
+            tags=tuple(tags or ()),
+            created_at=now,
+            updated_at=now,
+        )
+        self._entries[name] = entry
+        self._write()
+        self._emit("vault.secret_stored", {"name": name, "tags": list(entry.tags)})
+
+    def retrieve_secret(self, name: str) -> Optional[str]:
+        entry = self._entries.get(name)
+        if not entry:
+            return None
+        self._emit("vault.secret_accessed", {"name": name})
+        return self._decrypt(entry.value)
+
+    def delete_secret(self, name: str) -> bool:
+        if name in self._entries:
+            del self._entries[name]
+            self._write()
+            self._emit("vault.secret_deleted", {"name": name})
+            return True
+        return False
+
+    def list_secrets(self, *, include_tags: bool = False) -> Dict[str, Sequence[str]]:
+        if include_tags:
+            return {name: entry.tags for name, entry in self._entries.items()}
+        return {name: () for name in self._entries}
+
+    def _encrypt(self, value: str) -> str:
+        if Fernet and self._mode == "fernet":
+            return self._cipher.encrypt(value.encode("utf-8")).decode("ascii")  # type: ignore[no-any-return]
+        return self._cipher.encrypt(value)  # type: ignore[no-any-return]
+
+    def _decrypt(self, token: str) -> str:
+        if Fernet and self._mode == "fernet":
+            return self._cipher.decrypt(token.encode("ascii")).decode("utf-8")  # type: ignore[no-any-return]
+        return self._cipher.decrypt(token)  # type: ignore[no-any-return]
+
+    def _emit(self, topic: str, payload: dict) -> None:
+        if self.telemetry:
+            self.telemetry.emit(topic, payload)
+
+    def _load(self) -> None:
+        if not self.storage_path.exists():
+            return
+        try:
+            data = json.loads(self.storage_path.read_text())
+            self._entries = {
+                name: VaultEntry(
+                    value=entry["value"],
+                    tags=tuple(entry.get("tags", ())),
+                    created_at=entry.get("created_at", datetime.utcnow().isoformat()),
+                    updated_at=entry.get("updated_at", datetime.utcnow().isoformat()),
+                )
+                for name, entry in data.items()
+            }
+        except json.JSONDecodeError:
+            self._entries = {}
+
+    def _write(self) -> None:
+        self.storage_path.parent.mkdir(parents=True, exist_ok=True)
+        data = {
+            name: {
+                "value": entry.value,
+                "tags": list(entry.tags),
+                "created_at": entry.created_at,
+                "updated_at": entry.updated_at,
+            }
+            for name, entry in self._entries.items()
+        }
+        self.storage_path.write_text(json.dumps(data, indent=2, sort_keys=True))
+
+
+__all__ = ["SecurityVault", "VaultEntry"]

--- a/phreak_v5/models.py
+++ b/phreak_v5/models.py
@@ -1,0 +1,177 @@
+"""Domain models shared across PHREAK v5 subsystems."""
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Dict, Iterable, Mapping, MutableMapping, Optional, Sequence
+
+
+class DeviceStatus(str, Enum):
+    UNKNOWN = "unknown"
+    ONLINE = "online"
+    OFFLINE = "offline"
+    FASTBOOT = "fastboot"
+    RECOVERY = "recovery"
+
+
+@dataclass(slots=True)
+class Device:
+    device_id: str
+    connection_uri: str
+    status: DeviceStatus = DeviceStatus.UNKNOWN
+    tags: Sequence[str] = field(default_factory=tuple)
+    metadata: Mapping[str, str] = field(default_factory=dict)
+
+    def with_status(self, status: DeviceStatus) -> "Device":
+        return Device(
+            device_id=self.device_id,
+            connection_uri=self.connection_uri,
+            status=status,
+            tags=self.tags,
+            metadata=self.metadata,
+        )
+
+
+@dataclass(slots=True)
+class DeviceBatch:
+    """Represents a logical grouping of devices using tags or ids."""
+
+    device_ids: Sequence[str] = field(default_factory=tuple)
+    tags: Sequence[str] = field(default_factory=tuple)
+
+
+class CommandPriority(Enum):
+    LOW = 10
+    NORMAL = 20
+    HIGH = 30
+    CRITICAL = 40
+
+
+@dataclass(slots=True)
+class CommandRequest:
+    action: str
+    device_ids: Sequence[str]
+    arguments: Mapping[str, str] = field(default_factory=dict)
+    requested_by: str = "system"
+    priority: CommandPriority = CommandPriority.NORMAL
+    request_id: str = field(default_factory=lambda: uuid.uuid4().hex)
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+    def with_devices(self, devices: Sequence[str]) -> "CommandRequest":
+        return CommandRequest(
+            action=self.action,
+            device_ids=tuple(devices),
+            arguments=self.arguments,
+            requested_by=self.requested_by,
+            priority=self.priority,
+            request_id=self.request_id,
+            created_at=self.created_at,
+        )
+
+    def to_json(self) -> str:
+        payload = {
+            "action": self.action,
+            "device_ids": list(self.device_ids),
+            "arguments": dict(self.arguments),
+            "requested_by": self.requested_by,
+            "priority": self.priority.name,
+            "request_id": self.request_id,
+            "created_at": self.created_at.isoformat(),
+        }
+        return json.dumps(payload, sort_keys=True)
+
+
+class CommandStatus(str, Enum):
+    ACCEPTED = "accepted"
+    RUNNING = "running"
+    SUCCESS = "success"
+    FAILED = "failed"
+    REJECTED = "rejected"
+
+
+@dataclass(slots=True)
+class CommandResult:
+    request_id: str
+    device_id: str
+    status: CommandStatus
+    stdout: str = ""
+    stderr: str = ""
+    exit_code: Optional[int] = None
+    started_at: Optional[datetime] = None
+    completed_at: Optional[datetime] = None
+
+    def mark_running(self) -> None:
+        self.status = CommandStatus.RUNNING
+        self.started_at = datetime.utcnow()
+
+    def mark_complete(self, status: CommandStatus, *, stdout: str = "", stderr: str = "", exit_code: Optional[int] = None) -> None:
+        self.status = status
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exit_code = exit_code
+        self.completed_at = datetime.utcnow()
+
+
+@dataclass(slots=True)
+class PolicyContext:
+    device_ids: Sequence[str]
+    action: str
+    requested_by: str
+    arguments: Mapping[str, str]
+
+    @classmethod
+    def from_request(cls, request: CommandRequest) -> "PolicyContext":
+        return cls(
+            device_ids=request.device_ids,
+            action=request.action,
+            requested_by=request.requested_by,
+            arguments=request.arguments,
+        )
+
+
+@dataclass(slots=True)
+class PolicyDecision:
+    allowed: bool
+    reasons: Sequence[str] = field(default_factory=tuple)
+
+    @classmethod
+    def allow(cls) -> "PolicyDecision":
+        return cls(True, ())
+
+    @classmethod
+    def deny(cls, reasons: Iterable[str]) -> "PolicyDecision":
+        return cls(False, tuple(reasons))
+
+
+@dataclass(slots=True)
+class PolicyRule:
+    name: str
+    description: str
+    condition: str
+    effect: str = "allow"
+    tags: Sequence[str] = field(default_factory=tuple)
+
+
+@dataclass(slots=True)
+class TelemetryEvent:
+    topic: str
+    payload: MutableMapping[str, object]
+    timestamp: datetime = field(default_factory=datetime.utcnow)
+
+
+__all__ = [
+    "Device",
+    "DeviceStatus",
+    "DeviceBatch",
+    "CommandRequest",
+    "CommandPriority",
+    "CommandResult",
+    "CommandStatus",
+    "PolicyContext",
+    "PolicyDecision",
+    "PolicyRule",
+    "TelemetryEvent",
+]

--- a/phreak_v5/presentation/__init__.py
+++ b/phreak_v5/presentation/__init__.py
@@ -1,0 +1,12 @@
+"""Presentation layer surfaces for PHREAK v5."""
+from .curses_ui import CursesControlRoom
+from .api import AutomationAPI
+from .web import WebOperatorCockpit
+from .observability import ObservabilityService
+
+__all__ = [
+    "CursesControlRoom",
+    "AutomationAPI",
+    "WebOperatorCockpit",
+    "ObservabilityService",
+]

--- a/phreak_v5/presentation/api.py
+++ b/phreak_v5/presentation/api.py
@@ -1,0 +1,46 @@
+"""Automation API facade for PHREAK v5."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..core.router import CommandRouter
+from ..models import CommandRequest, PolicyContext
+from ..services.device_graph import DeviceGraphOrchestrator
+from ..telemetry import TelemetryBus
+
+
+class AutomationAPI:
+    """Simple async facade mimicking a REST/gRPC handler."""
+
+    def __init__(
+        self,
+        *,
+        telemetry: TelemetryBus,
+        router: CommandRouter,
+        device_graph: DeviceGraphOrchestrator,
+    ) -> None:
+        self.telemetry = telemetry
+        self.router = router
+        self.device_graph = device_graph
+
+    async def submit_command(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        request = CommandRequest(
+            action=payload["action"],
+            device_ids=tuple(payload.get("device_ids", ())),
+            arguments=payload.get("arguments", {}),
+            requested_by=payload.get("requested_by", "api"),
+        )
+        context = PolicyContext.from_request(request)
+        await self.router.dispatch(request, context)
+        response = {"request_id": request.request_id, "status": "accepted"}
+        self.telemetry.emit("api.command_submitted", response)
+        return response
+
+    def list_devices(self) -> Dict[str, Any]:
+        devices = self.device_graph.describe()
+        payload = {"devices": devices}
+        self.telemetry.emit("api.list_devices", {"count": len(devices)})
+        return payload
+
+
+__all__ = ["AutomationAPI"]

--- a/phreak_v5/presentation/curses_ui.py
+++ b/phreak_v5/presentation/curses_ui.py
@@ -1,0 +1,64 @@
+"""Text-based control room stub for PHREAK v5."""
+from __future__ import annotations
+
+import asyncio
+from typing import Optional
+
+from ..core.router import CommandRouter
+from ..models import CommandRequest, PolicyContext
+from ..services.device_graph import DeviceGraphOrchestrator
+from ..telemetry import TelemetryBus
+
+
+class CursesControlRoom:
+    """Lightweight facade for a future curses-based UI."""
+
+    def __init__(
+        self,
+        *,
+        telemetry: TelemetryBus,
+        device_graph: DeviceGraphOrchestrator,
+        router: CommandRouter,
+    ) -> None:
+        self.telemetry = telemetry
+        self.device_graph = device_graph
+        self.router = router
+        self._updates = asyncio.Queue()
+        self.telemetry.subscribe("device_graph.status_updated", self._on_event)
+        self.telemetry.subscribe("command.completed", self._on_event)
+
+    async def _on_event(self, event) -> None:  # type: ignore[override]
+        await self._updates.put(event)
+
+    def render_dashboard(self) -> str:
+        lines = ["PHREAK v5 :: Control Room", "=========================="]
+        for info in self.device_graph.describe():
+            lines.append(
+                f"{info['device_id']:<20} {info['status']:<10} tags={','.join(info['tags'])}"
+            )
+        return "\n".join(lines)
+
+    async def run_command(
+        self,
+        *,
+        device_id: str,
+        action: str,
+        arguments: Optional[dict] = None,
+        requested_by: str = "operator",
+    ) -> None:
+        request = CommandRequest(
+            action=action,
+            device_ids=(device_id,),
+            arguments=arguments or {},
+            requested_by=requested_by,
+        )
+        context = PolicyContext.from_request(request)
+        await self.router.dispatch(request, context)
+
+    async def poll_updates(self):
+        while True:
+            event = await self._updates.get()
+            yield event
+
+
+__all__ = ["CursesControlRoom"]

--- a/phreak_v5/presentation/observability.py
+++ b/phreak_v5/presentation/observability.py
@@ -1,0 +1,48 @@
+"""Observability surface for PHREAK v5."""
+from __future__ import annotations
+
+from collections import deque
+from typing import Deque, Dict
+
+from ..core.logging import AuditLoggingKernel
+from ..telemetry import TelemetryBus
+
+
+class ObservabilityService:
+    """Collects telemetry metrics and exposes recent events."""
+
+    def __init__(self, *, telemetry: TelemetryBus, audit_log: AuditLoggingKernel) -> None:
+        self.telemetry = telemetry
+        self.audit_log = audit_log
+        self._events: Deque[dict] = deque(maxlen=128)
+        self._metrics: Dict[str, int] = {}
+        self.telemetry.subscribe("*", self._on_event)
+
+    async def _on_event(self, event) -> None:  # type: ignore[override]
+        self._events.append(
+            {
+                "topic": event.topic,
+                "payload": dict(event.payload),
+                "timestamp": event.timestamp.isoformat(),
+            }
+        )
+        self._metrics[event.topic] = self._metrics.get(event.topic, 0) + 1
+
+    def recent_events(self) -> list[dict]:
+        return list(self._events)
+
+    def metrics(self) -> Dict[str, int]:
+        return dict(self._metrics)
+
+    def audit_tail(self, limit: int = 20) -> list[dict]:
+        return [
+            {
+                "timestamp": record.timestamp,
+                "kind": record.kind,
+                "hash": record.hash,
+            }
+            for record in self.audit_log.tail(limit)
+        ]
+
+
+__all__ = ["ObservabilityService"]

--- a/phreak_v5/presentation/web.py
+++ b/phreak_v5/presentation/web.py
@@ -1,0 +1,34 @@
+"""Web operator cockpit stubs for PHREAK v5."""
+from __future__ import annotations
+
+import json
+from typing import Dict
+
+from ..services.device_graph import DeviceGraphOrchestrator
+from ..telemetry import TelemetryBus
+
+
+class WebOperatorCockpit:
+    """Prepares state for a future web UI implementation."""
+
+    def __init__(self, *, telemetry: TelemetryBus, device_graph: DeviceGraphOrchestrator) -> None:
+        self.telemetry = telemetry
+        self.device_graph = device_graph
+
+    def snapshot_state(self) -> Dict[str, object]:
+        devices = self.device_graph.describe()
+        summary = {
+            "total": len(devices),
+            "online": sum(1 for d in devices if d["status"] == "online"),
+            "fastboot": sum(1 for d in devices if d["status"] == "fastboot"),
+        }
+        return {"devices": devices, "summary": summary}
+
+    def export_state_json(self) -> str:
+        state = self.snapshot_state()
+        payload = json.dumps(state, indent=2, sort_keys=True)
+        self.telemetry.emit("web.snapshot", {"device_count": state["summary"]["total"]})
+        return payload
+
+
+__all__ = ["WebOperatorCockpit"]

--- a/phreak_v5/services/__init__.py
+++ b/phreak_v5/services/__init__.py
@@ -1,0 +1,16 @@
+"""Operator services exposed by the PHREAK v5 control tower."""
+from .backup import BackupSyncEngine
+from .device_graph import DeviceGraphOrchestrator
+from .firmware import FirmwareSuite
+from .forensics import ForensicsHub
+from .ml import MLDiagnostics
+from .plugins import PluginRuntime
+
+__all__ = [
+    "BackupSyncEngine",
+    "DeviceGraphOrchestrator",
+    "FirmwareSuite",
+    "ForensicsHub",
+    "MLDiagnostics",
+    "PluginRuntime",
+]

--- a/phreak_v5/services/backup.py
+++ b/phreak_v5/services/backup.py
@@ -1,0 +1,60 @@
+"""Backup and cloud sync engine for PHREAK v5."""
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+from ..telemetry import TelemetryBus
+
+
+class BackupSyncEngine:
+    """Manages encrypted backup manifests and scheduling."""
+
+    def __init__(
+        self,
+        *,
+        telemetry: TelemetryBus,
+        storage_path: Path,
+    ) -> None:
+        self.telemetry = telemetry
+        self.storage_path = storage_path
+        self.storage_path.mkdir(parents=True, exist_ok=True)
+        self._manifest_path = self.storage_path / "backups.json"
+        self._manifest: Dict[str, list[dict]] = {}
+        self._load_manifest()
+
+    def schedule_backup(self, device_id: str) -> Path:
+        timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+        backup_dir = self.storage_path / device_id
+        backup_dir.mkdir(parents=True, exist_ok=True)
+        backup_path = backup_dir / f"backup_{timestamp}.tar"
+        backup_path.write_bytes(b"")  # placeholder archive
+        entry = {"device_id": device_id, "path": str(backup_path), "created_at": datetime.utcnow().isoformat()}
+        self._manifest.setdefault(device_id, []).append(entry)
+        self._write_manifest()
+        self.telemetry.emit(
+            "backup.created",
+            {"device_id": device_id, "path": str(backup_path)},
+        )
+        return backup_path
+
+    def list_backups(self, device_id: Optional[str] = None) -> Iterable[dict]:
+        if device_id:
+            return list(self._manifest.get(device_id, ()))
+        entries = []
+        for records in self._manifest.values():
+            entries.extend(records)
+        return entries
+
+    def _load_manifest(self) -> None:
+        if not self._manifest_path.exists():
+            return
+        self._manifest = json.loads(self._manifest_path.read_text())
+
+    def _write_manifest(self) -> None:
+        self._manifest_path.write_text(json.dumps(self._manifest, indent=2, sort_keys=True))
+
+
+__all__ = ["BackupSyncEngine"]

--- a/phreak_v5/services/device_graph.py
+++ b/phreak_v5/services/device_graph.py
@@ -1,0 +1,126 @@
+"""Device graph orchestrator for PHREAK v5."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, Iterable, List, Optional, Set, Tuple
+
+from ..models import Device, DeviceBatch, DeviceStatus
+from ..telemetry import TelemetryBus
+
+
+@dataclass(slots=True)
+class DeviceNode:
+    device: Device
+    tags: Set[str] = field(default_factory=set)
+    status: DeviceStatus = DeviceStatus.UNKNOWN
+    last_seen: datetime = field(default_factory=datetime.utcnow)
+
+    def update(self, *, tags: Optional[Iterable[str]] = None, status: Optional[DeviceStatus] = None) -> None:
+        if tags is not None:
+            self.tags = set(tags)
+        if status is not None:
+            self.status = status
+        self.last_seen = datetime.utcnow()
+
+
+@dataclass(slots=True)
+class DeviceBatchResolution:
+    device_ids: Tuple[str, ...]
+    missing: Tuple[str, ...]
+    tags: Tuple[str, ...]
+
+
+class DeviceGraphOrchestrator:
+    """Maintains a live view of connected devices and groupings."""
+
+    def __init__(self, *, telemetry: TelemetryBus, audit_log=None) -> None:
+        self.telemetry = telemetry
+        self.audit_log = audit_log
+        self._nodes: Dict[str, DeviceNode] = {}
+
+    def register_device(self, device: Device) -> None:
+        node = DeviceNode(device=device, tags=set(device.tags), status=device.status)
+        self._nodes[device.device_id] = node
+        self.telemetry.emit(
+            "device_graph.registered",
+            {
+                "device_id": device.device_id,
+                "tags": list(node.tags),
+                "status": node.status.value,
+            },
+        )
+
+    def remove_device(self, device_id: str) -> None:
+        if self._nodes.pop(device_id, None):
+            self.telemetry.emit("device_graph.removed", {"device_id": device_id})
+
+    def update_status(self, device_id: str, status: DeviceStatus) -> None:
+        node = self._nodes.get(device_id)
+        if not node:
+            return
+        node.update(status=status)
+        self.telemetry.emit(
+            "device_graph.status_updated",
+            {"device_id": device_id, "status": status.value},
+        )
+
+    def add_tags(self, device_id: str, tags: Iterable[str]) -> None:
+        node = self._nodes.get(device_id)
+        if not node:
+            return
+        node.tags.update(tags)
+        node.last_seen = datetime.utcnow()
+        self.telemetry.emit(
+            "device_graph.tags_added",
+            {"device_id": device_id, "tags": list(tags)},
+        )
+
+    def remove_tags(self, device_id: str, tags: Iterable[str]) -> None:
+        node = self._nodes.get(device_id)
+        if not node:
+            return
+        for tag in tags:
+            node.tags.discard(tag)
+        node.last_seen = datetime.utcnow()
+        self.telemetry.emit(
+            "device_graph.tags_removed",
+            {"device_id": device_id, "tags": list(tags)},
+        )
+
+    def list_devices(self) -> List[Device]:
+        return [node.device for node in self._nodes.values()]
+
+    def resolve_batch(self, batch: DeviceBatch) -> DeviceBatchResolution:
+        resolved: Set[str] = set(batch.device_ids)
+        missing: Set[str] = set()
+        if batch.tags:
+            for node in self._nodes.values():
+                if set(batch.tags).issubset(node.tags):
+                    resolved.add(node.device.device_id)
+        for device_id in list(resolved):
+            if device_id not in self._nodes:
+                resolved.discard(device_id)
+                missing.add(device_id)
+        return DeviceBatchResolution(
+            device_ids=tuple(sorted(resolved)),
+            missing=tuple(sorted(missing)),
+            tags=tuple(batch.tags),
+        )
+
+    def find_by_tag(self, tag: str) -> List[Device]:
+        return [node.device for node in self._nodes.values() if tag in node.tags]
+
+    def describe(self) -> List[dict]:
+        return [
+            {
+                "device_id": node.device.device_id,
+                "status": node.status.value,
+                "tags": sorted(node.tags),
+                "last_seen": node.last_seen.isoformat(),
+            }
+            for node in self._nodes.values()
+        ]
+
+
+__all__ = ["DeviceGraphOrchestrator", "DeviceBatchResolution"]

--- a/phreak_v5/services/firmware.py
+++ b/phreak_v5/services/firmware.py
@@ -1,0 +1,121 @@
+"""Firmware ingestion and management for PHREAK v5."""
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+from ..core.logging import AuditLoggingKernel
+from ..telemetry import TelemetryBus
+
+
+@dataclass(slots=True)
+class FirmwareRecord:
+    identifier: str
+    filename: str
+    sha256: str
+    metadata: Dict[str, object] = field(default_factory=dict)
+    created_at: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+
+
+class FirmwareSuite:
+    """Handles firmware ingestion, verification, and lookup."""
+
+    def __init__(
+        self,
+        *,
+        telemetry: TelemetryBus,
+        audit_log: AuditLoggingKernel,
+        storage_path: Path,
+    ) -> None:
+        self.telemetry = telemetry
+        self.audit_log = audit_log
+        self.storage_path = storage_path
+        self.storage_path.mkdir(parents=True, exist_ok=True)
+        self._index_path = self.storage_path / "index.json"
+        self._records: Dict[str, FirmwareRecord] = {}
+        self._load_index()
+
+    def ingest_firmware(self, source: Path, *, metadata: Optional[dict] = None) -> str:
+        if not source.exists():
+            raise FileNotFoundError(source)
+        sha256 = self._hash_file(source)
+        identifier = sha256[:16]
+        target_name = f"{identifier}_{source.name}"
+        target_path = self.storage_path / target_name
+        shutil.copy2(source, target_path)
+        record = FirmwareRecord(
+            identifier=identifier,
+            filename=target_name,
+            sha256=sha256,
+            metadata=metadata or {},
+        )
+        self._records[identifier] = record
+        self._write_index()
+        self.audit_log.append_custom(
+            "firmware.ingested",
+            {
+                "identifier": identifier,
+                "filename": target_name,
+                "sha256": sha256,
+            },
+        )
+        self.telemetry.emit(
+            "firmware.ingested",
+            {"identifier": identifier, "sha256": sha256, "metadata": record.metadata},
+        )
+        return identifier
+
+    def get_record(self, identifier: str) -> Optional[FirmwareRecord]:
+        return self._records.get(identifier)
+
+    def verify(self, identifier: str) -> bool:
+        record = self._records.get(identifier)
+        if not record:
+            return False
+        path = self.storage_path / record.filename
+        if not path.exists():
+            return False
+        return self._hash_file(path) == record.sha256
+
+    def list_records(self) -> Iterable[FirmwareRecord]:
+        return list(self._records.values())
+
+    def _hash_file(self, path: Path) -> str:
+        digest = hashlib.sha256()
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(8192), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    def _load_index(self) -> None:
+        if not self._index_path.exists():
+            return
+        data = json.loads(self._index_path.read_text())
+        for identifier, entry in data.items():
+            self._records[identifier] = FirmwareRecord(
+                identifier=identifier,
+                filename=entry["filename"],
+                sha256=entry["sha256"],
+                metadata=entry.get("metadata", {}),
+                created_at=entry.get("created_at", datetime.utcnow().isoformat()),
+            )
+
+    def _write_index(self) -> None:
+        data = {
+            identifier: {
+                "filename": record.filename,
+                "sha256": record.sha256,
+                "metadata": record.metadata,
+                "created_at": record.created_at,
+            }
+            for identifier, record in self._records.items()
+        }
+        self._index_path.write_text(json.dumps(data, indent=2, sort_keys=True))
+
+
+__all__ = ["FirmwareSuite", "FirmwareRecord"]

--- a/phreak_v5/services/forensics.py
+++ b/phreak_v5/services/forensics.py
@@ -1,0 +1,97 @@
+"""Forensics and analytics hub for PHREAK v5."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Optional
+
+from ..core.logging import AuditLoggingKernel
+from ..core.router import CommandRouter
+from ..models import CommandRequest, PolicyContext
+from ..telemetry import TelemetryBus
+
+
+DEFAULT_COLLECTION_COMMANDS = [
+    {"action": "shell", "arguments": {"command": "getprop"}},
+    {"action": "pull", "arguments": {"path": "/system/build.prop"}},
+]
+
+
+@dataclass(slots=True)
+class ForensicArtifact:
+    name: str
+    description: str
+    path: Path
+
+
+class ForensicsHub:
+    """Coordinates snapshot collection and reporting."""
+
+    def __init__(
+        self,
+        *,
+        audit_log: AuditLoggingKernel,
+        telemetry: TelemetryBus,
+        storage_path: Optional[Path] = None,
+    ) -> None:
+        self.audit_log = audit_log
+        self.telemetry = telemetry
+        self.storage_path = storage_path or Path("~/.phreak/forensics").expanduser()
+        self.storage_path.mkdir(parents=True, exist_ok=True)
+
+    async def collect_snapshot(
+        self,
+        device_id: str,
+        router: CommandRouter,
+        *,
+        commands: Optional[list[dict]] = None,
+    ) -> Path:
+        timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+        snapshot_dir = self.storage_path / device_id / timestamp
+        snapshot_dir.mkdir(parents=True, exist_ok=True)
+        metadata: Dict[str, object] = {
+            "device_id": device_id,
+            "collected_at": datetime.utcnow().isoformat(),
+            "artifacts": [],
+        }
+
+        cmds = commands or DEFAULT_COLLECTION_COMMANDS
+        executed_commands = []
+        for spec in cmds:
+            request = CommandRequest(
+                action=spec["action"],
+                device_ids=(device_id,),
+                arguments=spec.get("arguments", {}),
+                requested_by="forensics",
+            )
+            context = PolicyContext.from_request(request)
+            try:
+                await router.dispatch(request, context)
+                status = "submitted"
+            except Exception as exc:  # pragma: no cover - defensive
+                status = f"error: {exc}"
+            executed_commands.append(
+                {
+                    "action": spec["action"],
+                    "arguments": spec.get("arguments", {}),
+                    "status": status,
+                }
+            )
+
+        metadata["commands"] = executed_commands
+        metadata_path = snapshot_dir / "metadata.json"
+        metadata_path.write_text(json.dumps(metadata, indent=2, sort_keys=True))
+        self.audit_log.append_custom(
+            "forensics.snapshot",
+            {"device_id": device_id, "path": str(snapshot_dir)},
+        )
+        self.telemetry.emit(
+            "forensics.snapshot_created",
+            {"device_id": device_id, "path": str(snapshot_dir)},
+        )
+        return snapshot_dir
+
+
+__all__ = ["ForensicsHub", "ForensicArtifact"]

--- a/phreak_v5/services/ml.py
+++ b/phreak_v5/services/ml.py
@@ -1,0 +1,46 @@
+"""Heuristic ML diagnostics placeholder for PHREAK v5."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Tuple
+
+from ..telemetry import TelemetryBus
+
+
+@dataclass(slots=True)
+class DiagnosticResult:
+    label: str
+    confidence: float
+    explanation: str
+
+
+class MLDiagnostics:
+    """Applies heuristic classifiers to telemetry and logs."""
+
+    def __init__(self, *, telemetry: TelemetryBus) -> None:
+        self.telemetry = telemetry
+        self._rules: List[Tuple[str, float, str]] = [
+            ("bootloop", 0.7, "Detected repeated boot animation log entries"),
+            ("modem_crash", 0.8, "Modem subsystem crash keywords present"),
+            ("storage_fault", 0.6, "I/O errors observed in dmesg output"),
+        ]
+
+    def analyze_log(self, log_text: str) -> DiagnosticResult:
+        lowered = log_text.lower()
+        for label, base_conf, explanation in self._rules:
+            if label.replace("_", " ") in lowered or label in lowered:
+                result = DiagnosticResult(label=label, confidence=base_conf + 0.1, explanation=explanation)
+                self.telemetry.emit(
+                    "ml.diagnostic",
+                    {
+                        "label": result.label,
+                        "confidence": result.confidence,
+                    },
+                )
+                return result
+        result = DiagnosticResult(label="unknown", confidence=0.2, explanation="No heuristics matched")
+        self.telemetry.emit("ml.diagnostic", {"label": result.label, "confidence": result.confidence})
+        return result
+
+
+__all__ = ["MLDiagnostics", "DiagnosticResult"]

--- a/phreak_v5/services/plugins.py
+++ b/phreak_v5/services/plugins.py
@@ -1,0 +1,134 @@
+"""Plugin runtime for PHREAK v5."""
+from __future__ import annotations
+
+import importlib.util
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from ..core.logging import AuditLoggingKernel
+from ..telemetry import TelemetryBus
+
+
+@dataclass(slots=True)
+class PluginMetadata:
+    name: str
+    version: str
+    description: str = ""
+    capabilities: List[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class Plugin:
+    metadata: PluginMetadata
+    module: object
+    path: Path
+
+    def has_hook(self, name: str) -> bool:
+        return hasattr(self.module, name)
+
+    def call_hook(self, name: str, *args, **kwargs):
+        if not self.has_hook(name):
+            raise AttributeError(f"Plugin {self.metadata.name} lacks hook {name}")
+        return getattr(self.module, name)(*args, **kwargs)
+
+
+class PluginRuntime:
+    """Loads plugin bundles described by a JSON manifest."""
+
+    def __init__(
+        self,
+        *,
+        search_paths: Iterable[Path],
+        telemetry: TelemetryBus,
+        audit_log: AuditLoggingKernel,
+    ) -> None:
+        self.search_paths = [Path(path) for path in search_paths]
+        self.telemetry = telemetry
+        self.audit_log = audit_log
+        self.plugins: List[Plugin] = []
+
+    def scan(self) -> None:
+        self.plugins.clear()
+        for root in self.search_paths:
+            if not root.exists():
+                continue
+            for manifest_path in root.glob("*/plugin.json"):
+                plugin = self._load_plugin(manifest_path)
+                if plugin:
+                    self.plugins.append(plugin)
+
+    def get_plugin(self, name: str) -> Optional[Plugin]:
+        for plugin in self.plugins:
+            if plugin.metadata.name == name:
+                return plugin
+        return None
+
+    def _load_plugin(self, manifest_path: Path) -> Optional[Plugin]:
+        try:
+            manifest = json.loads(manifest_path.read_text())
+        except json.JSONDecodeError:
+            self.telemetry.emit(
+                "plugin.error",
+                {"path": str(manifest_path), "error": "invalid manifest"},
+            )
+            return None
+
+        metadata = PluginMetadata(
+            name=manifest.get("name", manifest_path.parent.name),
+            version=str(manifest.get("version", "0.0.0")),
+            description=manifest.get("description", ""),
+            capabilities=list(manifest.get("capabilities", [])),
+        )
+
+        entrypoint = manifest.get("entry", "main.py")
+        module_path = manifest_path.parent / entrypoint
+        if not module_path.exists():
+            self.telemetry.emit(
+                "plugin.error",
+                {"path": str(module_path), "error": "missing entrypoint"},
+            )
+            return None
+
+        spec = importlib.util.spec_from_file_location(metadata.name, module_path)
+        if not spec or not spec.loader:
+            self.telemetry.emit(
+                "plugin.error",
+                {"path": str(module_path), "error": "unable to load"},
+            )
+            return None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)  # type: ignore[assignment]
+
+        plugin = Plugin(metadata=metadata, module=module, path=manifest_path.parent)
+        self.audit_log.append_custom(
+            "plugin.loaded",
+            {
+                "name": metadata.name,
+                "version": metadata.version,
+                "path": str(plugin.path),
+            },
+        )
+        self.telemetry.emit(
+            "plugin.loaded",
+            {
+                "name": metadata.name,
+                "version": metadata.version,
+                "capabilities": metadata.capabilities,
+            },
+        )
+        return plugin
+
+    def call_hook(self, plugin_name: str, hook_name: str, *args, **kwargs):
+        plugin = self.get_plugin(plugin_name)
+        if not plugin:
+            raise KeyError(plugin_name)
+        self.telemetry.emit(
+            "plugin.hook_invoked",
+            {"name": plugin_name, "hook": hook_name},
+        )
+        return plugin.call_hook(hook_name, *args, **kwargs)
+
+
+__all__ = ["PluginRuntime", "Plugin", "PluginMetadata"]

--- a/phreak_v5/telemetry.py
+++ b/phreak_v5/telemetry.py
@@ -1,0 +1,69 @@
+"""Simple pub/sub telemetry bus for PHREAK v5."""
+from __future__ import annotations
+
+import asyncio
+from collections import defaultdict
+from typing import Any, AsyncIterator, Awaitable, Callable, Dict, List, MutableMapping
+
+from .models import TelemetryEvent
+
+TelemetryCallback = Callable[[TelemetryEvent], Awaitable[None]]
+
+
+class TelemetryBus:
+    """Asynchronous in-process pub/sub bus."""
+
+    def __init__(self) -> None:
+        self._subscribers: Dict[str, List[TelemetryCallback]] = defaultdict(list)
+        self._queue: "asyncio.Queue[TelemetryEvent]" = asyncio.Queue()
+        self._dispatcher_task: asyncio.Task[None] | None = None
+
+    def subscribe(self, topic: str, callback: TelemetryCallback) -> None:
+        self._subscribers[topic].append(callback)
+
+    def unsubscribe(self, topic: str, callback: TelemetryCallback) -> None:
+        callbacks = self._subscribers.get(topic)
+        if not callbacks:
+            return
+        try:
+            callbacks.remove(callback)
+        except ValueError:
+            pass
+
+    def emit(self, topic: str, payload: MutableMapping[str, Any]) -> None:
+        event = TelemetryEvent(topic=topic, payload=payload)
+        self._queue.put_nowait(event)
+        if not self._dispatcher_task:
+            self._dispatcher_task = asyncio.create_task(self._dispatch_loop())
+
+    async def iter_events(self, topic: str) -> AsyncIterator[TelemetryEvent]:
+        queue: "asyncio.Queue[TelemetryEvent]" = asyncio.Queue()
+
+        async def _forward(event: TelemetryEvent) -> None:
+            await queue.put(event)
+
+        self.subscribe(topic, _forward)
+        try:
+            while True:
+                yield await queue.get()
+        finally:
+            self.unsubscribe(topic, _forward)
+
+    async def _dispatch_loop(self) -> None:
+        while not self._queue.empty() or self._has_subscribers():
+            event = await self._queue.get()
+            await self._dispatch(event)
+        self._dispatcher_task = None
+
+    async def _dispatch(self, event: TelemetryEvent) -> None:
+        callbacks = list(self._subscribers.get(event.topic, ()))
+        callbacks += self._subscribers.get("*", [])
+        if not callbacks:
+            return
+        await asyncio.gather(*(cb(event) for cb in callbacks))
+
+    def _has_subscribers(self) -> bool:
+        return any(self._subscribers.values())
+
+
+__all__ = ["TelemetryBus"]


### PR DESCRIPTION
## Summary
- add the `phreak_v5` package with a control tower orchestrator wiring telemetry, policies, routing, and storage primitives
- implement core services for connections, auditing, vaulting, firmware, backups, forensics, ML diagnostics, and plugin runtime aligned with the v5 blueprint
- provide presentation-layer stubs and documentation updates describing how the new blueprint code is organized

## Testing
- `python -m compileall phreak_v5`


------
https://chatgpt.com/codex/tasks/task_e_68cfd78bcd28832c92dab9d43365fd33