### PR TITLE
Add device registry with phone number lookup support

### DIFF
--- a/phreak_v5/__init__.py
+++ b/phreak_v5/__init__.py
@@ -11,9 +11,19 @@ from .core.logging import AuditLoggingKernel
 from .core.policy import PolicyEngine, PolicyRule
 from .core.router import CommandRouter
 from .core.vault import SecurityVault
-from .models import CommandRequest, Device, DeviceBatch, PolicyContext
+from .models import (
+    CommandRequest,
+    Device,
+    DeviceBatch,
+    DeviceLookupResult,
+    DeviceStatus,
+    EnrolledDevice,
+    LocationFix,
+    PolicyContext,
+)
 from .services.backup import BackupSyncEngine
 from .services.device_graph import DeviceGraphOrchestrator
+from .services.enrollment import DeviceRegistry
 from .services.firmware import FirmwareSuite
 from .services.forensics import ForensicsHub
 from .services.ml import MLDiagnostics
@@ -31,6 +41,7 @@ class ControlTowerComponents:
     audit_log: AuditLoggingKernel
     vault: SecurityVault
     device_graph: DeviceGraphOrchestrator
+    device_registry: DeviceRegistry
     forensics_hub: ForensicsHub
     firmware_suite: FirmwareSuite
     backup_engine: BackupSyncEngine
@@ -78,6 +89,9 @@ class PhreakControlTower:
         self.device_graph = DeviceGraphOrchestrator(
             telemetry=self.telemetry, audit_log=self.audit_log
         )
+        self.device_registry = DeviceRegistry(
+            telemetry=self.telemetry,
+        )
         self.forensics_hub = ForensicsHub(
             audit_log=self.audit_log,
             telemetry=self.telemetry,
@@ -107,6 +121,7 @@ class PhreakControlTower:
             audit_log=self.audit_log,
             vault=self.vault,
             device_graph=self.device_graph,
+            device_registry=self.device_registry,
             forensics_hub=self.forensics_hub,
             firmware_suite=self.firmware_suite,
             backup_engine=self.backup_engine,
@@ -122,9 +137,37 @@ class PhreakControlTower:
             self.connection_matrix.register_device(device)
             self.device_graph.register_device(device)
 
+    def register_enrolled_device(
+        self,
+        enrolled_device: EnrolledDevice,
+        *,
+        connection: Optional[Device] = None,
+    ) -> None:
+        """Register an enrolled device and optionally its live connection info."""
+
+        stored = self.device_registry.register_device(enrolled_device)
+        if connection:
+            if connection.device_id != stored.device_id:
+                raise ValueError("connection device_id must match enrolled device")
+            self.connection_matrix.register_device(connection)
+            self.device_graph.register_device(connection)
+
     def remove_device(self, device_id: str) -> None:
         self.connection_matrix.unregister_device(device_id)
         self.device_graph.remove_device(device_id)
+        self.device_registry.unregister_device(device_id)
+
+    # -- Enrollment lookups ----------------------------------------------
+    def locate_device_by_phone(self, phone_number: str) -> DeviceLookupResult:
+        return self.device_registry.locate_device(phone_number)
+
+    def update_enrolled_device_location(
+        self, device_id: str, location: LocationFix
+    ) -> None:
+        self.device_registry.update_location(device_id, location)
+
+    def update_enrolled_device_status(self, device_id: str, status: DeviceStatus) -> None:
+        self.device_registry.update_status(device_id, status)
 
     # -- Command dispatch -------------------------------------------------
     async def dispatch(self, request: CommandRequest) -> None:

--- a/phreak_v5/models.py
+++ b/phreak_v5/models.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 
 import json
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime
 from enum import Enum
-from typing import Dict, Iterable, Mapping, MutableMapping, Optional, Sequence
+from typing import Dict, Iterable, Mapping, MutableMapping, Optional, Sequence, Tuple
 
 
 class DeviceStatus(str, Enum):
@@ -41,6 +41,76 @@ class DeviceBatch:
 
     device_ids: Sequence[str] = field(default_factory=tuple)
     tags: Sequence[str] = field(default_factory=tuple)
+
+
+@dataclass(slots=True)
+class LocationFix:
+    """GPS fix captured from a managed device."""
+
+    latitude: float
+    longitude: float
+    timestamp: datetime = field(default_factory=datetime.utcnow)
+
+    def to_tuple(self) -> Tuple[float, float, datetime]:
+        return self.latitude, self.longitude, self.timestamp
+
+
+@dataclass(slots=True)
+class EnrolledDevice:
+    """Metadata describing an enrolled device tracked by the control tower."""
+
+    device_id: str
+    phone_number: str
+    imei: Optional[str] = None
+    alias: Optional[str] = None
+    status: DeviceStatus = DeviceStatus.UNKNOWN
+    last_known_location: Optional[LocationFix] = None
+    metadata: Mapping[str, str] = field(default_factory=dict)
+
+    def with_phone_number(self, phone_number: str) -> "EnrolledDevice":
+        return replace(self, phone_number=phone_number)
+
+    def update_location(self, location: LocationFix) -> None:
+        self.last_known_location = location
+
+    def update_status(self, status: DeviceStatus) -> None:
+        self.status = status
+
+
+@dataclass(slots=True)
+class DeviceLocationRecord:
+    """Summarised location state for presentation surfaces."""
+
+    device_id: str
+    status: DeviceStatus
+    alias: Optional[str] = None
+    last_known_location: Optional[LocationFix] = None
+
+    @property
+    def map_url(self) -> Optional[str]:
+        if not self.last_known_location:
+            return None
+        return (
+            f"https://maps.google.com/?q={self.last_known_location.latitude},"
+            f"{self.last_known_location.longitude}"
+        )
+
+
+@dataclass(slots=True)
+class DeviceLookupResult:
+    """Result of locating devices by phone number."""
+
+    query: str
+    normalized_phone_number: str
+    matches: Tuple[DeviceLocationRecord, ...] = field(default_factory=tuple)
+
+    @property
+    def has_matches(self) -> bool:
+        return bool(self.matches)
+
+    @property
+    def is_ambiguous(self) -> bool:
+        return len(self.matches) > 1
 
 
 class CommandPriority(Enum):
@@ -166,6 +236,10 @@ __all__ = [
     "Device",
     "DeviceStatus",
     "DeviceBatch",
+    "LocationFix",
+    "EnrolledDevice",
+    "DeviceLocationRecord",
+    "DeviceLookupResult",
     "CommandRequest",
     "CommandPriority",
     "CommandResult",

--- a/phreak_v5/services/__init__.py
+++ b/phreak_v5/services/__init__.py
@@ -1,6 +1,7 @@
 """Operator services exposed by the PHREAK v5 control tower."""
 from .backup import BackupSyncEngine
 from .device_graph import DeviceGraphOrchestrator
+from .enrollment import DeviceRegistry
 from .firmware import FirmwareSuite
 from .forensics import ForensicsHub
 from .ml import MLDiagnostics
@@ -9,6 +10,7 @@ from .plugins import PluginRuntime
 __all__ = [
     "BackupSyncEngine",
     "DeviceGraphOrchestrator",
+    "DeviceRegistry",
     "FirmwareSuite",
     "ForensicsHub",
     "MLDiagnostics",

--- a/phreak_v5/services/enrollment.py
+++ b/phreak_v5/services/enrollment.py
@@ -1,0 +1,195 @@
+"""Device enrollment and lookup helpers for PHREAK v5."""
+from __future__ import annotations
+
+import re
+from dataclasses import replace
+from typing import Dict, Optional, Set, Tuple
+
+from ..models import (
+    DeviceLookupResult,
+    DeviceLocationRecord,
+    DeviceStatus,
+    EnrolledDevice,
+    LocationFix,
+)
+
+try:
+    from ..telemetry import TelemetryBus
+except ImportError:  # pragma: no cover - helpful during static analysis
+    TelemetryBus = None  # type: ignore
+
+E164_PATTERN = re.compile(r"^\+[1-9]\d{1,14}$")
+
+
+def normalize_phone_number(phone_number: str, default_country_code: str = "+1") -> str:
+    """Normalise phone numbers into the E.164 format."""
+
+    if not phone_number:
+        raise ValueError("phone_number is required")
+
+    stripped = phone_number.strip()
+    digits = re.sub(r"\D", "", stripped)
+
+    if stripped.startswith("+"):
+        normalized = "+" + digits
+    else:
+        if not default_country_code:
+            raise ValueError("default_country_code is required for local numbers")
+        country = re.sub(r"\D", "", default_country_code)
+        if not country:
+            raise ValueError("default_country_code must contain digits")
+        normalized = f"+{country}{digits}"
+
+    if not E164_PATTERN.match(normalized):
+        raise ValueError(f"invalid phone number format: {phone_number}")
+
+    return normalized
+
+
+class DeviceRegistry:
+    """Stores metadata for enrolled devices and resolves phone lookups."""
+
+    def __init__(
+        self,
+        *,
+        telemetry: Optional["TelemetryBus"] = None,
+        default_country_code: str = "+1",
+    ) -> None:
+        self.telemetry = telemetry
+        self.default_country_code = default_country_code
+        self._devices: Dict[str, EnrolledDevice] = {}
+        self._phone_index: Dict[str, Set[str]] = {}
+
+    # -- Registration -------------------------------------------------
+    def register_device(self, device: EnrolledDevice) -> EnrolledDevice:
+        normalized_phone = normalize_phone_number(
+            device.phone_number, self.default_country_code
+        )
+        stored = replace(device, phone_number=normalized_phone)
+
+        existing = self._devices.get(stored.device_id)
+        if existing:
+            self._remove_phone_index(existing.phone_number, existing.device_id)
+
+        self._devices[stored.device_id] = stored
+        self._phone_index.setdefault(normalized_phone, set()).add(stored.device_id)
+        self._emit(
+            "device_registry.registered",
+            {
+                "device_id": stored.device_id,
+                "phone_number": stored.phone_number,
+                "status": stored.status.value,
+            },
+        )
+        return stored
+
+    def unregister_device(self, device_id: str) -> None:
+        device = self._devices.pop(device_id, None)
+        if not device:
+            return
+        self._remove_phone_index(device.phone_number, device_id)
+        self._emit("device_registry.unregistered", {"device_id": device_id})
+
+    # -- Updates ------------------------------------------------------
+    def update_status(self, device_id: str, status: DeviceStatus) -> None:
+        device = self._get_required_device(device_id)
+        device.update_status(status)
+        self._emit(
+            "device_registry.status_updated",
+            {"device_id": device_id, "status": status.value},
+        )
+
+    def update_location(self, device_id: str, location: LocationFix) -> None:
+        device = self._get_required_device(device_id)
+        device.update_location(location)
+        self._emit(
+            "device_registry.location_updated",
+            {
+                "device_id": device_id,
+                "phone_number": device.phone_number,
+                "latitude": location.latitude,
+                "longitude": location.longitude,
+                "timestamp": location.timestamp.isoformat(),
+            },
+        )
+
+    def update_alias(self, device_id: str, alias: Optional[str]) -> None:
+        device = self._get_required_device(device_id)
+        device.alias = alias
+        self._emit(
+            "device_registry.alias_updated",
+            {"device_id": device_id, "alias": alias or ""},
+        )
+
+    # -- Lookup -------------------------------------------------------
+    def get_device(self, device_id: str) -> Optional[EnrolledDevice]:
+        return self._devices.get(device_id)
+
+    def lookup_by_phone(self, phone_number: str) -> Tuple[EnrolledDevice, ...]:
+        normalized = normalize_phone_number(phone_number, self.default_country_code)
+        device_ids = self._phone_index.get(normalized, set())
+        return tuple(self._devices[device_id] for device_id in device_ids)
+
+    def locate_device(self, phone_number: str) -> DeviceLookupResult:
+        normalized = normalize_phone_number(phone_number, self.default_country_code)
+        device_ids = self._phone_index.get(normalized, set())
+
+        matches = tuple(
+            DeviceLocationRecord(
+                device_id=self._devices[device_id].device_id,
+                alias=self._devices[device_id].alias,
+                status=self._devices[device_id].status,
+                last_known_location=self._devices[device_id].last_known_location,
+            )
+            for device_id in sorted(device_ids)
+        )
+
+        topic = "device_registry.lookup.miss"
+        if matches:
+            topic = (
+                "device_registry.lookup.ambiguous"
+                if len(matches) > 1
+                else "device_registry.lookup.hit"
+            )
+        self._emit(
+            topic,
+            {
+                "query": phone_number,
+                "normalized": normalized,
+                "matches": [record.device_id for record in matches],
+            },
+        )
+
+        return DeviceLookupResult(
+            query=phone_number,
+            normalized_phone_number=normalized,
+            matches=matches,
+        )
+
+    # -- Internal -----------------------------------------------------
+    def _remove_phone_index(self, phone_number: str, device_id: str) -> None:
+        device_ids = self._phone_index.get(phone_number)
+        if not device_ids:
+            return
+        device_ids.discard(device_id)
+        if not device_ids:
+            self._phone_index.pop(phone_number, None)
+
+    def _get_required_device(self, device_id: str) -> EnrolledDevice:
+        device = self._devices.get(device_id)
+        if not device:
+            raise KeyError(f"device '{device_id}' is not registered")
+        return device
+
+    def _emit(self, topic: str, payload: dict) -> None:
+        if not self.telemetry:
+            return
+        try:
+            self.telemetry.emit(topic, payload)
+        except RuntimeError:
+            # If no event loop is running (e.g. unit tests), suppress telemetry errors.
+            pass
+
+
+__all__ = ["DeviceRegistry", "normalize_phone_number"]
+

--- a/tests/test_device_registry.py
+++ b/tests/test_device_registry.py
@@ -1,0 +1,70 @@
+from datetime import datetime
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from phreak_v5.models import DeviceStatus, EnrolledDevice, LocationFix
+from phreak_v5.services.enrollment import DeviceRegistry, normalize_phone_number
+
+
+def test_normalize_phone_number_with_default_country_code():
+    assert normalize_phone_number("(555) 010-1234") == "+15550101234"
+
+
+def test_normalize_phone_number_requires_digits():
+    with pytest.raises(ValueError):
+        normalize_phone_number("abc")
+
+
+def test_register_and_locate_device_unique_match():
+    registry = DeviceRegistry(telemetry=None)
+    device = EnrolledDevice(
+        device_id="device-1",
+        phone_number="5550109876",
+        imei="123456789012345",
+        alias="Warehouse Tablet",
+        status=DeviceStatus.ONLINE,
+        last_known_location=LocationFix(
+            latitude=37.7749,
+            longitude=-122.4194,
+            timestamp=datetime(2024, 1, 1, 12, 0, 0),
+        ),
+    )
+
+    registry.register_device(device)
+    result = registry.locate_device("+1 (555) 010-9876")
+
+    assert result.normalized_phone_number == "+15550109876"
+    assert result.has_matches is True
+    assert result.is_ambiguous is False
+    record = result.matches[0]
+    assert record.device_id == "device-1"
+    assert record.alias == "Warehouse Tablet"
+    assert record.status == DeviceStatus.ONLINE
+    assert record.last_known_location.latitude == pytest.approx(37.7749)
+    assert record.map_url == "https://maps.google.com/?q=37.7749,-122.4194"
+
+
+def test_locate_device_multiple_matches_returns_all():
+    registry = DeviceRegistry(telemetry=None)
+    device_a = EnrolledDevice(device_id="device-A", phone_number="+15550101111")
+    device_b = EnrolledDevice(device_id="device-B", phone_number="(555) 010-1111")
+
+    registry.register_device(device_a)
+    registry.register_device(device_b)
+
+    result = registry.locate_device("5550101111")
+
+    assert result.is_ambiguous is True
+    assert {record.device_id for record in result.matches} == {"device-A", "device-B"}
+
+
+def test_locate_device_no_match_returns_empty_result():
+    registry = DeviceRegistry(telemetry=None)
+    result = registry.locate_device("+15550102222")
+
+    assert result.has_matches is False
+    assert result.matches == ()


### PR DESCRIPTION
## Summary
- add domain models to represent enrolled devices, GPS fixes, and lookup results
- implement a device registry service that normalizes phone numbers and locates devices by their last known location
- expose registry helpers from the control tower facade and cover the lookup flow with pytest tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db3cbdb488832c98cf61f9f75ef9f0